### PR TITLE
Add support for Python 3

### DIFF
--- a/pipdiff/pipdiff.py
+++ b/pipdiff/pipdiff.py
@@ -9,7 +9,7 @@ from xmlrpclib import ServerProxy
 pypi = ServerProxy("http://pypi.python.org/pypi")
 
 
-def main():    
+def main():
     try:
         from pip import get_installed_distributions
     except ImportError:
@@ -21,18 +21,18 @@ def main():
         remote = ''
         project_name = distribution.project_name
         releases = pypi.package_releases(project_name)
-    
+
         if not releases:
             pypi.package_releases(project_name.capitalize())
-    
+
         if releases:
             version = parse_version(releases[0])
-    
+
             if version > distribution.parsed_version:
                 remote = "PyPI:{0}=={1}".format(project_name, releases[0])
         else:
             remote = "PyPI:{0} not found".format(project_name)
-    
+
         local = "{0}=={1}".format(project_name, distribution.version)
         print "{0:40} {1}".format(local, remote)
     return True

--- a/pipdiff/pipdiff.py
+++ b/pipdiff/pipdiff.py
@@ -4,10 +4,15 @@
 # Copied here for the purpose of adding it to PyPI
 
 from pkg_resources import parse_version
-from xmlrpclib import ServerProxy
+try:
+    from xmlrpclib import ServerProxy
+except ImportError:
+    import xmlrpc.client
 
-pypi = ServerProxy("http://pypi.python.org/pypi")
-
+try:
+    pypi = ServerProxy("http://pypi.python.org/pypi")
+except NameError:
+    pypi = xmlrpc.client.ServerProxy("http://pypi.python.org/pypi")
 
 def main():
     try:
@@ -27,14 +32,13 @@ def main():
 
         if releases:
             version = parse_version(releases[0])
-
-            if version > distribution.parsed_version:
+            if str(version) > str(distribution.parsed_version):
                 remote = "PyPI:{0}=={1}".format(project_name, releases[0])
         else:
             remote = "PyPI:{0} not found".format(project_name)
 
         local = "{0}=={1}".format(project_name, distribution.version)
-        print "{0:40} {1}".format(local, remote)
+        print("{0:40} {1}".format(local, remote))
     return True
 
 

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ version = '0.1'
 try:
     REQUIREMENTS = open('requirements.txt').read()
 except:
-    REQUIREMENTS = [        
+    REQUIREMENTS = [
     ]
 
 setup(name='pipdiff',
@@ -24,7 +24,7 @@ setup(name='pipdiff',
     author_email='little_pea@list.ru',
     url='https://github.com/ogt/pipdiff',
     license='BSD',
-    packages=find_packages(),    
+    packages=find_packages(),
     zip_safe=False,
     install_requires=REQUIREMENTS,
     entry_points={


### PR DESCRIPTION
I love this utility and would really like to use it with Python 3. This pull request adds a couple of try/except blocks to handle differences in Python 2/3 usage of `xmlrpclib`. In addition, Python 3 throws `TypeError: unorderable types: SetuptoolsVersion() > SetuptoolsVersion()` on the version comparison. Making both objects strings fixes that. Finally, one change to a `print` statement was needed.

Please consider merging this and pushing a new version up to PyPi. Thanks.