### PR TITLE
Access PyPI Using https, as Now Required

### DIFF
--- a/pipdiff/pipdiff.py
+++ b/pipdiff/pipdiff.py
@@ -10,9 +10,9 @@ except ImportError:
     import xmlrpc.client
 
 try:
-    pypi = ServerProxy("http://pypi.python.org/pypi")
+    pypi = ServerProxy("https://pypi.python.org/pypi")
 except NameError:
-    pypi = xmlrpc.client.ServerProxy("http://pypi.python.org/pypi")
+    pypi = xmlrpc.client.ServerProxy("https://pypi.python.org/pypi")
 
 def main():
     try:

--- a/pipdiff/pipdiff.py
+++ b/pipdiff/pipdiff.py
@@ -14,6 +14,7 @@ try:
 except NameError:
     pypi = xmlrpc.client.ServerProxy("https://pypi.python.org/pypi")
 
+
 def main():
     try:
         from pip import get_installed_distributions
@@ -21,7 +22,8 @@ def main():
         from sys import exit
         exit("pip not available")
 
-    for distribution in sorted(get_installed_distributions(),
+    for distribution in sorted(
+            get_installed_distributions(),
             key=lambda distribution: distribution.project_name):
         remote = ''
         project_name = distribution.project_name


### PR DESCRIPTION
pipdiff began failing because it seems PyPI now requires using https. I've changed the URLs and done some minor PEP8 formatting that my editor noticed. 